### PR TITLE
#patch. use system user on startup DB actions

### DIFF
--- a/EngineBay.Authentication/AuthenticationModule.cs
+++ b/EngineBay.Authentication/AuthenticationModule.cs
@@ -55,7 +55,7 @@ namespace EngineBay.Authentication
                         var applicationUserDto = await command.Handle(createUserDto, cancellation);
 
                         return Results.Ok(applicationUserDto);
-                    }).RequireAuthorization();
+                    }).AllowAnonymous();
 
                     break;
                 case AuthenticationTypes.Basic:

--- a/EngineBay.Authentication/BasicAuth/CurrentIdentityFromBasicAuth.cs
+++ b/EngineBay.Authentication/BasicAuth/CurrentIdentityFromBasicAuth.cs
@@ -28,9 +28,7 @@
 
             if (context == null)
             {
-                var user = new SystemUser();
-                this.userId = user.Id;
-                this.Username = user.Username;
+                this.Username = DefaultAuthenticationConfigurationConstants.SystemUserName;
             }
             else if (string.IsNullOrEmpty(context.Request.Headers["Authorization"].ToString()))
             {
@@ -45,9 +43,9 @@
                 var credentialstring = Encoding.UTF8.GetString(Convert.FromBase64String(token));
                 var credentials = credentialstring.Split(':');
                 this.Username = credentials[0];
-
-                this.getCurrentUser = getCurrentUser;
             }
+
+            this.getCurrentUser = getCurrentUser;
         }
 
         public Guid UserId => this.GetUserIdAsync(CancellationToken.None).Result;

--- a/EngineBay.Authentication/Constants/CustomClaimTypes.cs
+++ b/EngineBay.Authentication/Constants/CustomClaimTypes.cs
@@ -2,7 +2,6 @@
 {
     public static class CustomClaimTypes
     {
-        public const string Name = "Name";
-        public const string Id = "Id";
+        public const string Name = "name";
     }
 }

--- a/EngineBay.Authentication/JwtBearerAuth/CurrentIdentityFromJwt.cs
+++ b/EngineBay.Authentication/JwtBearerAuth/CurrentIdentityFromJwt.cs
@@ -1,12 +1,19 @@
 ﻿namespace EngineBay.Authentication
 {
+    using System.Security.Claims;
     using EngineBay.Core;
     using Microsoft.AspNetCore.Http;
 
     public class CurrentIdentityFromJwt : ICurrentIdentity
     {
-        public CurrentIdentityFromJwt(IHttpContextAccessor httpContextAccessor)
+        private readonly GetCurrentUser getCurrentUser;
+
+        private Guid? userId;
+
+        public CurrentIdentityFromJwt(IHttpContextAccessor httpContextAccessor, GetCurrentUser getCurrentUser)
         {
+            this.getCurrentUser = getCurrentUser ?? throw new ArgumentNullException(nameof(getCurrentUser));
+
             if (httpContextAccessor == null)
             {
                 throw new ArgumentNullException(nameof(httpContextAccessor));
@@ -16,27 +23,40 @@
 
             if (context == null)
             {
-                var user = new SystemUser();
-                this.UserId = user.Id;
-                this.Username = user.Username;
+                this.Username = DefaultAuthenticationConfigurationConstants.SystemUserName;
             }
             else if (string.IsNullOrEmpty(context.Request.Headers["Authorization"].ToString()))
             {
                 var user = new UnauthenticatedUser();
-                this.UserId = user.Id;
+                this.userId = user.Id;
                 this.Username = user.Username;
             }
             else
             {
                 this.Username = httpContextAccessor.HttpContext?.User?.Claims.FirstOrDefault(c => c.Type == CustomClaimTypes.Name)?.Value ?? throw new ArgumentException("Could not find user name from JWT claim");
-
-                var idString = httpContextAccessor.HttpContext?.User?.Claims.FirstOrDefault(c => c.Type == CustomClaimTypes.Id)?.Value ?? throw new ArgumentException("Could not find user ID from JWT claim");
-                this.UserId = Guid.Parse(idString);
             }
         }
 
         public string Username { get; }
 
-        public Guid UserId { get; }
+        public Guid UserId => this.GetUserIdAsync(CancellationToken.None).Result;
+
+        public async Task<Guid> GetUserIdAsync(CancellationToken cancellation)
+        {
+            if (this.userId == null)
+            {
+                if (this.getCurrentUser is null)
+                {
+                    throw new ArgumentException(nameof(this.getCurrentUser) + " is null");
+                }
+
+                var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, this.Username) }, "JWT"));
+                var user = await this.getCurrentUser.Handle(claimsPrincipal, cancellation);
+
+                this.userId = user.Id;
+            }
+
+            return this.userId.Value;
+        }
     }
 }

--- a/EngineBay.Authentication/Queries/GetCurrentUser.cs
+++ b/EngineBay.Authentication/Queries/GetCurrentUser.cs
@@ -30,7 +30,7 @@ namespace EngineBay.Authentication
                 throw new ArgumentException(nameof(user.Identity));
             }
 
-            var claim = user.FindFirst(x => x.Type == "name");
+            var claim = user.FindFirst(x => x.Type == CustomClaimTypes.Name);
 
             var username = string.Empty;
 


### PR DESCRIPTION
Allow anonymous registration of new users for JWT Bearer authentication
Fetch system user from DB in CurrentIdentities to maintain the integrity of the assigned id. This is temporary, we need to rework all these current identitties.
